### PR TITLE
Fix ruby2.7 warnings

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,7 @@
 rvm:
 - 2.1.5
 - 2.2.2
+- 2.6.3
+- 2.7.0
 sudo: false
 cache: bundler

--- a/ks.gemspec
+++ b/ks.gemspec
@@ -32,7 +32,7 @@ Gem::Specification.new do |spec|
   spec.executables    = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths  = ['lib']
 
-  spec.add_development_dependency 'bundler', '~> 1'
+  spec.add_development_dependency 'bundler'
   spec.add_development_dependency 'rake', '~> 12'
   spec.add_development_dependency 'rspec', '~> 3'
   spec.add_development_dependency 'wetransfer_style', '0.6.0'

--- a/lib/ks.rb
+++ b/lib/ks.rb
@@ -30,7 +30,14 @@ module Ks
     @@caching_mutex.synchronize do
       return @@predefined_structs[k] if @@predefined_structs[k]
 
-      struct_ancestor = Struct.new(*members)
+      struct_ancestor = Struct.new(*members) do
+        def self.new(*args, **kwargs)
+          instance = allocate
+          instance.send(:initialize, *args, **kwargs)
+          instance
+        end
+      end
+
       predefined = Class.new(struct_ancestor) do
         class_eval <<-METHOD, __FILE__, __LINE__ + 1
           def initialize(#{members.map { |a| "#{a}:" }.join(', ')}) # def initialize(bar:, baz:)
@@ -75,7 +82,14 @@ module Ks
     @@caching_mutex.synchronize do
       return @@predefined_structs[k] if @@predefined_structs[k]
 
-      struct_ancestor = Struct.new(*members)
+      struct_ancestor = Struct.new(*members) do
+        def self.new(*args, **kwargs)
+          instance = allocate
+          instance.send(:initialize, *args, **kwargs)
+          instance
+        end
+      end
+
       predefined = Class.new(struct_ancestor) do
         class_eval <<-METHOD, __FILE__, __LINE__ + 1
           def initialize(#{members.map { |a| "#{a}:" }.join(', ')}, **) # def initialize(bar:, baz:, **)

--- a/spec/ks_spec.rb
+++ b/spec/ks_spec.rb
@@ -14,10 +14,16 @@ describe 'Ks' do
     end
 
     it 'raises when keyword arguments are omitted' do
+      expected_message = if RUBY_VERSION < '2.7'
+        'missing keyword: bar'
+      else
+        'missing keyword: :bar'
+      end
+
       k = Ks.strict(:foo, :bar)
       expect do
         k.new(foo: 1)
-      end.to raise_error(ArgumentError, 'missing keyword: :bar')
+      end.to raise_error(ArgumentError, expected_message)
     end
 
     it 'caches the created Struct ancestor even when using multiple threads' do

--- a/spec/ks_spec.rb
+++ b/spec/ks_spec.rb
@@ -17,7 +17,7 @@ describe 'Ks' do
       k = Ks.strict(:foo, :bar)
       expect do
         k.new(foo: 1)
-      end.to raise_error(ArgumentError, 'missing keyword: bar')
+      end.to raise_error(ArgumentError, 'missing keyword: :bar')
     end
 
     it 'caches the created Struct ancestor even when using multiple threads' do


### PR DESCRIPTION
Note: This includes the commits from #1 

When using `ks` under ruby 2.7, one is presented with warnings related to struct initialization:
```
ks/spec/ks_spec.rb:34: warning: Using the last argument as keyword parameters is deprecated; maybe ** should be added to the call
ks/lib/ks.rb:81: warning: The called method `initialize' is defined here
```
Which is confusing at first, since all the methods defined by the gem are correct given [the new keyword argument rules](https://www.ruby-lang.org/en/news/2019/12/12/separation-of-positional-and-keyword-arguments-in-ruby-3-0/).

My best guess is that this warning is actually being triggered by a call to `#initialize` from within the definition of `Struct` itself, but I'm not well-versed on the ruby internals enough to verify if that this is correct.

Regardless, the fix included in this PR (redefining `.new` for the `Ks` classes) seems to solve the issue and should help with keeping the gem to be forward compatible with Ruby 3.0 once it arrives.